### PR TITLE
GraphQL Java Generator is both a client and a server GraphQL Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@
 
 ### Schema First
 
+* [GraphQL Java Generator](https://github.com/graphql-java-generator) is a maven plugin that has two modes :
+
+    * The Client mode generates the Java classes that contains methods to call the GraphQL endpoint , and the POJO that will contain the data returned by the server.
+
+    * The Server mode generates the boilerplate code for graphql-java. It's an accelerator that makes it easier to use graphql-java. You'll only have to implement what's specific to your server, which are the joins between the GraphQL types.
+
 * [graphql-apigen](https://github.com/Distelli/graphql-apigen): Generate Java APIs with GraphQL Schemas
 
 * [graphql-java-tools](https://github.com/graphql-java/graphql-java-tools): A schema-first tool for graphql-java inspired by graphql-tools for JS


### PR DESCRIPTION
Hello,

  I developped a maven plugin that makes it easier to use GraphQL in Java:

- In client mode, it calls the endpoint, serialize the request and unserialize the response.
- In server mode, it generates a lot of code for graphql-java. Only the joins between the Objects must be coded by the developper.

I'll be happy that you add this tool in your projects list.


And that you take a look at the generated code, so that it is compliant with the way you want graphql-java to be used.

Etienne