### PR TITLE
Add library

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@
 
 * [test-graphql-java](https://github.com/vimalrajselvam/test-graphql-java): A simple library to help testing the GraphQL endpoint with schema files using any HTTP Client library.
 
+* [graphql-java-federation](https://github.com/rkudryashov/graphql-java-federation): A library to adapt graphql-java services to Apollo Federation specification
+
 ### Code First
 * [graphql-java-type-generator](https://github.com/graphql-java/graphql-java-type-generator): This library will autogenerate GraphQL types for usage in com.graphql-java:graphql-java
 


### PR DESCRIPTION
Hi,

I have added this schema-first approach library, which adds support of Apollo federation spec to GraphQL Java services. So it will be possible to create a single data graph combining schemas of different services.