### PR TITLE
graphql-java-plugin is now available as bot a maven and a gradle plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ### Schema First
 
-* [GraphQL Java Generator](https://github.com/graphql-java-generator) is available as a __maven plugin__ and a __Gradle plugin__. It has two modes :
+* [GraphQL Java Generator](https://github.com/graphql-java-generator) is available as a __Maven plugin__ and a __Gradle plugin__. It has two modes :
 
     * The Client mode generates the Java classes that contains methods to call the GraphQL endpoint , and the POJO that will contain the data returned by the server.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ### Schema First
 
-* [GraphQL Java Generator](https://github.com/graphql-java-generator) is a maven plugin that has two modes :
+* [GraphQL Java Generator](https://github.com/graphql-java-generator) is available as a __maven plugin__ and a __Gradle plugin__. It has two modes :
 
     * The Client mode generates the Java classes that contains methods to call the GraphQL endpoint , and the POJO that will contain the data returned by the server.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ### Schema First
 
-* [GraphQL Java Generator](https://github.com/graphql-java-generator) is available as a __Maven plugin__ and a __Gradle plugin__. It has two modes :
+* [GraphQL Java Generator](https://github.com/graphql-java-generator) is available as a [Maven plugin](https://github.com/graphql-java-generator/graphql-maven-plugin-project) and a [Gradle plugin](https://github.com/graphql-java-generator/graphql-gradle-plugin-project). It has two modes :
 
     * The Client mode generates the Java classes that contains methods to call the GraphQL endpoint , and the POJO that will contain the data returned by the server.
 


### PR DESCRIPTION
Hello,

  I extended the graphql-java-plugin. It was only a Maven plugin. There is now also a Gradle plugin, which has exactly the same capabilities.

Can you accept this PR, which just adds this information?

Regards
Etienne