### PR TITLE
Remove archived git repo for graphql-java-federation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@
 
 * [test-graphql-java](https://github.com/vimalrajselvam/test-graphql-java): A simple library to help testing the GraphQL endpoint with schema files using any HTTP Client library.
 
-* [graphql-java-federation](https://github.com/rkudryashov/graphql-java-federation): A library to adapt graphql-java services to Apollo Federation specification
 
 ### Code First
 * [graphql-java-annotations](https://github.com/graphql-java/graphql-java-annotations): Annotations-based syntax for GraphQL schema definition.


### PR DESCRIPTION
Removing [graphql-java-federation](https://github.com/rkudryashov/graphql-java-federation) is now an archived repository.

will raise a separate PR for adding [federation-jvm](https://github.com/apollographql/federation-jvm)