### PR TITLE
Adding graph-quilt/graphql-orchestrator-java

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@
 
 * [graphql-braid](https://bitbucket.org/atlassian/graphql-braid): Schema stitching - combines GraphQL backends into one schema.
 
+* [graphql-orchestrator-java](https://github.com/graph-quilt/graphql-orchestrator-java) GraphQL Orchestrator/Gateway library that supports Schema Stitching and Apollo Federation directives to combine schema from multiple GraphQL microservices into a single unified schema.
+
 * [test-graphql-java](https://github.com/vimalrajselvam/test-graphql-java): A simple library to help testing the GraphQL endpoint with schema files using any HTTP Client library.
 
 


### PR DESCRIPTION
Adding graphql-orchestrator-java project that uses the graphql-java execution strategy for orchestrating queries to multiple backends.