### PR TITLE
Add Elide library

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@
 
 * [graphql-jpa](https://github.com/jcrygier/graphql-jpa): JPA Implementation of GraphQL (builds on graphql-java)
 
+* [Elide](https://elide.io): Java library that lets you build model driven GraphQL APIs for CRUD and Analytics. It has first class support for JPA annotations.
+
 * [graphkool](https://github.com/beyondeye/graphkool): GraphQl-java utilities in kotlin
 
 * [schemagen-graphql](https://github.com/bpatters/schemagen-graphql): GraphQL-Java add-on that adds support for Schema Generation & Execution for enterprise level applications.


### PR DESCRIPTION
Elide is a Java library that allows creation of model driven GraphQL APIs. It offers first-class support for JPA annotations. It provides a Spring Boot Starter, or can be used stand-alone.